### PR TITLE
sensor/bma253: Use one interrupt line from BMA253

### DIFF
--- a/hw/drivers/sensors/bma253/include/bma253/bma253.h
+++ b/hw/drivers/sensors/bma253/include/bma253/bma253.h
@@ -180,6 +180,18 @@ struct bma253_int {
     struct sensor_int *ints;
 };
 
+/* Device private data */
+struct bma253_private_driver_data {
+    struct bma253_int * interrupt;
+    struct sensor_notify_ev_ctx notify_ctx;
+    struct sensor_read_ev_ctx read_ctx;
+    uint8_t registered_mask;
+
+    uint8_t int_num;
+    uint8_t int_route;
+    uint8_t int_ref_cnt;
+};
+
 /* The device itself */
 struct bma253 {
     /* Underlying OS device */
@@ -194,6 +206,9 @@ struct bma253 {
      * power mode if a function that requires a higher power mode is
      * currently running. */
     enum bma253_power_mode power;
+
+    /* Private driver data */
+    struct bma253_private_driver_data pdd;
 };
 
 /* Offset compensation is performed to target this given value, by axis */

--- a/hw/drivers/sensors/bma253/src/bma253_priv.h
+++ b/hw/drivers/sensors/bma253/src/bma253_priv.h
@@ -265,6 +265,11 @@ enum int_route {
     INT_ROUTE_BOTH  = 3,
 };
 
+enum bma253_int_num {
+    INT1_PIN,
+    INT2_PIN
+};
+
 /* Pin routing settings of all interrupts */
 struct int_routes {
     enum int_route flat_int_route;

--- a/hw/drivers/sensors/bma253/syscfg.yml
+++ b/hw/drivers/sensors/bma253/syscfg.yml
@@ -36,6 +36,9 @@ syscfg.defs:
     BMA253_INT_PIN_DEVICE:
         description: 'Interrupt pin number 1 or 2 on accelerometer device'
         value: 1
+    BMA253_INT2_PIN_DEVICE:
+        description: 'Interrupt pin number 1 or 2 on accelerometer device'
+        value: 2
     BMA253_INT_PIN_HOST:
         description: 'Interrupt pin number on host device connected to INT1 on device'
         value: 20

--- a/hw/sensor/creator/src/sensor_creator.c
+++ b/hw/sensor/creator/src/sensor_creator.c
@@ -183,10 +183,11 @@ static struct sensor_itf i2c_0_itf_lis = {
     .si_type = SENSOR_ITF_I2C,
     .si_num  = 0,
     .si_addr = 0x18,
-    .si_configured_ints_num = 2,
     .si_ints = {
-       { MYNEWT_VAL(BMA253_INT_PIN_HOST), MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)},
-       { MYNEWT_VAL(BMA253_INT2_PIN_HOST), MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)}
+       { MYNEWT_VAL(BMA253_INT_PIN_HOST), MYNEWT_VAL(BMA253_INT_PIN_DEVICE),
+                                         MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)},
+       { MYNEWT_VAL(BMA253_INT2_PIN_HOST), MYNEWT_VAL(BMA253_INT2_PIN_DEVICE),
+                                       MYNEWT_VAL(BMA253_INT_CFG_ACTIVE)}
     },
 };
 #endif

--- a/hw/sensor/include/sensor/sensor.h
+++ b/hw/sensor/include/sensor/sensor.h
@@ -385,7 +385,7 @@ typedef int (*sensor_set_notification_t)(struct sensor *,
                                          sensor_event_type_t);
 
 /**
- * Un set the notification expectation for a targeted set of events for the
+ * Unset the notification expectation for a targeted set of events for the
  * specific sensor.
  *
  * @param The sensor.
@@ -396,12 +396,23 @@ typedef int (*sensor_set_notification_t)(struct sensor *,
 typedef int (*sensor_unset_notification_t)(struct sensor *,
                                            sensor_event_type_t);
 
+/**
+ * Let driver handle interrupt in the sensor context
+ *
+ * @param The sensor.
+ * @param Interrupt argument
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+typedef int (*sensor_handle_interrupt_t)(struct sensor *);
+
 struct sensor_driver {
     sensor_read_func_t sd_read;
     sensor_get_config_func_t sd_get_config;
     sensor_set_trigger_thresh_t sd_set_trigger_thresh;
     sensor_set_notification_t sd_set_notification;
     sensor_unset_notification_t sd_unset_notification;
+    sensor_handle_interrupt_t sd_handle_interrupt;
 };
 
 struct sensor_timestamp {
@@ -411,7 +422,8 @@ struct sensor_timestamp {
 };
 
 struct sensor_int {
-    uint8_t pin;
+    uint8_t host_pin;
+    uint8_t device_pin;
     uint8_t active;
 };
 
@@ -438,7 +450,6 @@ struct sensor_itf {
     /* Sensor interface interrupts pins */
     /* XXX We should probably remove low/high pins and replace it with those
      */
-    uint8_t si_configured_ints_num;
     struct sensor_int si_ints[MYNEWT_VAL(SENSOR_MAX_INTERRUPTS_PINS)];
 };
 
@@ -819,6 +830,14 @@ sensor_set_watermark_thresh(char *, struct sensor_type_traits *);
  */
 void
 sensor_mgr_put_notify_evt(struct sensor_notify_ev_ctx *);
+
+/**
+ * Puts a interrupt event on the sensor manager evq
+ *
+ * @param interrupt event context
+ */
+void
+sensor_mgr_put_interrupt_evt(struct sensor *);
 
 /**
  * Puts read event on the sensor manager evq

--- a/hw/sensor/src/sensor.c
+++ b/hw/sensor/src/sensor.c
@@ -1017,10 +1017,19 @@ sensor_register_notifier(struct sensor *sensor,
                          struct sensor_notifier *notifier)
 {
     int rc;
+    struct sensor_notifier *tmp;
 
     rc = sensor_lock(sensor);
     if (rc != 0) {
         goto err;
+    }
+
+    /* Check if notifier is not already on the list */
+    SLIST_FOREACH(tmp, &sensor->s_notifier_list, sn_next) {
+        if (notifier == tmp) {
+            rc = SYS_EINVAL;
+            goto err;
+        }
     }
 
     SLIST_INSERT_HEAD(&sensor->s_notifier_list, notifier, sn_next);


### PR DESCRIPTION
With this patch sensor API changed a bit in order to support handling different interrupts types on one INT line.  In order to do it, there is new event to sensor when interrupt occurs. On this event sensor just call sd_driver_handle_interrupt method from sensor_driver so it can read interrupt status from the bma253 and send appropriate event.

